### PR TITLE
Issue 12 - Add support of nodeenv (virtualenv)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,13 @@
 # Log files
 *.log
 
-# npm
-/node_modules/
-
 # WebPack output
 /dist/
+
+# NodeEnv
+/env/
+
+# npm
+/node_modules/
 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # app-avtozip
 
-[![Circle CI](https://circleci.com/gh/AvtoZip/app-avtozip/tree/master.svg?style=shield)](https://circleci.com/gh/AvtoZip/app-avtozip/tree/master)
+[![Circle CI](https://circleci.com/gh/AvtoZip/app-avtozip.svg?style=shield)](https://circleci.com/gh/AvtoZip/app-avtozip)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "url": "git+https://github.com/AvtoZip/app-avtozip"
   },
   "author": "AvtoZip developers",
-  "license": "ISC",
+  "license": "UNLICENSED",
+  "private": true,
   "bugs": {
     "url": "https://github.com/AvtoZip/app-avtozip/issues"
   },
@@ -30,6 +31,6 @@
     "eslint-config-airbnb": "6.2.0",
     "eslint-loader": "1.3.0",
     "eslint-plugin-react": "4.2.3",
-    "webpack-dev-server": "1.14.1"
+    "webpack-dev-server": "1.12.1"
   }
 }


### PR DESCRIPTION
Added exclusions to `env` which should be NodeEnv folder to `.gitignore`
Make repo private and UNLICENSED and updated README file
Updated npm packages

Fixes #12
